### PR TITLE
Adding sending query building class.

### DIFF
--- a/src/server/callback-manager.js
+++ b/src/server/callback-manager.js
@@ -16,7 +16,6 @@ import ManiaPlanetCalls from './callbacks/maniaplanet-callbacks';
 export default class {
 
   /**
-   *
    * @param {ServerClient} client
    */
   constructor(client) {
@@ -30,7 +29,7 @@ export default class {
    * @param {string} options.callback Callback name that will be fired by the GBX Client.
    * @param {string} options.event Converting into event name.
    * @param {object} options.parameters Parameters mapping.
-   * @param {array} options.game Optional game strings. Provide the titleid of the parent title (the game title).
+   * @param {object} options.game Optional game strings. Provide the titleid of the parent title (the game title).
    */
   register(options) {
     let self = this;

--- a/src/server/client.js
+++ b/src/server/client.js
@@ -6,6 +6,7 @@ import Gbx from 'gbxremote';
 import { EventEmitter } from 'events';
 
 import CallbackManager from './callback-manager';
+import Send from './send';
 
 import config from './../util/configuration';
 import times from './../lib/times';
@@ -30,6 +31,15 @@ export default class extends EventEmitter {
     this.callback = null;
 
     this.server = app.config.server;
+  }
+
+  /**
+   * Build a sending query.
+   *
+   * @returns {{}|*}
+   */
+  send() {
+    return new Send(this.app, this);
   }
 
   /**

--- a/src/server/client.js
+++ b/src/server/client.js
@@ -116,7 +116,10 @@ export default class extends EventEmitter {
           }
           self.app.log.debug("Connection to ManiaPlanet Server, Successfully enabled callbacks!");
 
-          self.gbx.query('ChatSendServerMessage', ["$o$f90Mania$z$o$f90JS$z$fff: Booting Controller..."]);
+          // Send welcome message
+          self.send().chat("$o$f90Mania$z$o$f90JS$z$fff: Booting Controller...").exec();
+
+          // self.gbx.query('ChatSendServerMessage', []);
 
           return resolve(res);
         });

--- a/src/server/send.js
+++ b/src/server/send.js
@@ -29,6 +29,8 @@ export default class {
    * @param {string} text
    * @param {object} options Optional options.
    * @param {string} options.source Source of message, could be 'player', 'server' or 'global' (default)
+   *
+   * @return {self}
    */
   chat(text, options) {
     options = options || {};
@@ -40,6 +42,7 @@ export default class {
         params: [text]
       }
     }
+    return this;
   }
 
 

--- a/src/server/send.js
+++ b/src/server/send.js
@@ -1,0 +1,69 @@
+/**
+ * Send anything to the MP Server.
+ * Sending query builder.
+ */
+
+/**
+ * Send
+ * @class Send
+ */
+export default class {
+
+  /**
+   * Construct sending query instance.
+   *
+   * @param {App} app
+   * @param {ServerClient} client
+   */
+  constructor(app, client) {
+    this.app = app;
+    this.client = client;
+
+    // Contains the sending queue. (raw).
+    this.query = {};
+  }
+
+  /**
+   * Send chat message.
+   *
+   * @param {string} text
+   * @param {object} options Optional options.
+   * @param {string} options.source Source of message, could be 'player', 'server' or 'global' (default)
+   */
+  chat(text, options) {
+    options = options || {};
+    let source = options.source || 'global';
+
+    if (source === 'global') {
+      this.query = {
+        query: 'ChatSendServerMessage',
+        params: [text]
+      }
+    }
+  }
+
+
+  /**
+   * Execute builded query.
+   *
+   * @return {Promise|boolean}
+   */
+  exec() {
+    if (! this.query.hasOwnProperty('query')) {
+      return false;
+    }
+    let self = this;
+
+    // Execute and return result (raw).
+    return new Promise((resolve, reject) => {
+      self.client.gbx.query(self.query.query, self.query.params, (err, res) => {
+        if (err) {
+          return reject(err);
+        }
+        return resolve(res);
+      });
+    });
+  }
+}
+
+


### PR DESCRIPTION
This class can be easily used by core and plugins to send most used queries to the client.

Such as send chat.

``` javascript
client.send().chat(“Hi!”).exec();
```

(return promise of course, but could be ignored).
