### PR TITLE
Adding Child Logger for plugins, ability to listen for manialink actions.

### DIFF
--- a/src/plugin/plugin.js
+++ b/src/plugin/plugin.js
@@ -57,8 +57,8 @@ export default class {
           // Save plugin details to plugin array.
           this.plugins[pluginId] = new PluginClass();
 
-          // Inject App.
-          this.plugins[pluginId].inject(this.app, config);
+          // Inject App, options and child logger.
+          this.plugins[pluginId].inject(this.app, config, this.app.log.child({plugin: pluginId}));
 
           // Register node
           this.graph.addNode(pluginId);

--- a/src/plugin/plugin.js
+++ b/src/plugin/plugin.js
@@ -87,8 +87,7 @@ export default class {
     try {
       this.determinateOrder();
     } catch (err) {
-      console.error(err);
-      return;
+      return Promise.reject(err);
     }
 
     this.app.log.debug("Starting all plugins... Calling init...");

--- a/src/server/callbacks/maniaplanet-callbacks.js
+++ b/src/server/callbacks/maniaplanet-callbacks.js
@@ -96,6 +96,23 @@ export default function (manager) {
     }
   });
 
+
+  // manialink answer
+  manager.register({
+    callback: 'ManiaPlanet.PlayerManialinkPageAnswer',
+    event: 'player.manialinkanswer',
+    parameters: {
+      playerid: 0,
+      login: 1,
+      answer: 2,
+      entries: 3
+    },
+    flow: (app, params) => {
+      // First call the ui manager.
+      return app.uiFacade.manager.answer(params);
+    }
+  });
+
   // TODO: ManiaPlanet.PlayerManialinkPageAnswer
 
 

--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -97,4 +97,24 @@ export default class {
     this.facade.manager.update(this);
   }
 
+  /**
+   * On Answer.
+   * @param {string} action Action Name.
+   * @param {callback} callback Callback.
+   * @params {object} callback.data
+   */
+  on (action, callback) {
+    this.facade.manager.on(action, callback);
+  }
+
+  /**
+   * Once Answer.
+   * @param {string} action Action Name.
+   * @param {callback} callback Callback.
+   * @params {object} callback.data
+   */
+  once (action, callback) {
+    this.facade.manager.once(action, callback);
+  }
+
 }

--- a/src/ui/ui-manager.js
+++ b/src/ui/ui-manager.js
@@ -3,6 +3,8 @@
  */
 import * as hash from 'object-hash';
 
+import { EventEmitter } from 'events';
+
 /**
  * UI Manager
  *
@@ -12,9 +14,12 @@ import * as hash from 'object-hash';
  *
  * @property {Map} interfaces  Player Specifics Interfaces.
  */
-export default class {
+export default class extends EventEmitter {
 
   constructor (app) {
+    super();
+    this.setMaxListeners(0);
+
     this.app = app;
 
     this.interfaces = new Map();
@@ -107,5 +112,20 @@ export default class {
           });
       }
     });
+  }
+
+  /**
+   * ManiaLink Answer Event.
+   *
+   * @param {object} params
+   * @param {number} params.playerid
+   * @param {string} params.login
+   * @param {string} params.answer
+   * @param {[]}     params.entries
+   */
+  answer (params) {
+    // Emit event on manager.
+    this.emit(params.answer, params);
+    return Promise.resolve();
   }
 }


### PR DESCRIPTION
Like this in a plugin: (where this.recordsWidget is a interface builder
instance).

```
this.recordsWidget.on('OpenLocalRecords', (data) => {
this.log.debug(data);
});
```
