### PR TITLE
Fixed time formating for times less than 100ms

### DIFF
--- a/src/Util/Times.ts
+++ b/src/Util/Times.ts
@@ -11,7 +11,7 @@ import { sprintf } from 'sprintf-js';
 export function stringTime (input) {
   let min = Math.floor(input / (1000 * 60));
   let sec = Math.floor((input - min * 60 * 1000) / 1000);
-  let msec = (input + "").substr((input + "").length - 3);
+  let msec = input % 1000;
 
   if(msec) {
     if(min > 9) {


### PR DESCRIPTION
Times less than 100 ms, eg `52`, would show as `00:00.002`. Now it shows as `00:00.052`
